### PR TITLE
Add an Official API release column to the reference

### DIFF
--- a/content/en/docs/misc/thin_client_api_reference.md
+++ b/content/en/docs/misc/thin_client_api_reference.md
@@ -32,11 +32,11 @@ Rust binding (`thin_client/src`), and a Python binding
 
 The official API documentation for each binding:
 
-| Language | Official API documentation |
-| --- | --- |
-| Go | [pkg.go.dev](https://pkg.go.dev/github.com/katzenpost/katzenpost/client/thin) |
-| Rust | [docs.rs](https://docs.rs/katzenpost_thin_client/latest/katzenpost_thin_client/) |
-| Python | [Python Thin Client API](/docs/python_thin_client_api/) |
+| Language | Official API documentation | Official API release |
+| --- | --- | --- |
+| Go | [pkg.go.dev](https://pkg.go.dev/github.com/katzenpost/katzenpost/client/thin) | [git tags](https://github.com/katzenpost/katzenpost/tags) |
+| Rust | [docs.rs](https://docs.rs/katzenpost_thin_client/latest/katzenpost_thin_client/) | [crates.io](https://crates.io/crates/katzenpost_thin_client) |
+| Python | [Python Thin Client API](/docs/python_thin_client_api/) | [PyPI](https://pypi.org/project/katzenpost_thinclient/) |
 
 This reference describes the following pinned binding versions:
 

--- a/tools/thin-client-api-gen/overlay/00-preamble.md
+++ b/tools/thin-client-api-gen/overlay/00-preamble.md
@@ -32,11 +32,11 @@ Rust binding (`thin_client/src`), and a Python binding
 
 The official API documentation for each binding:
 
-| Language | Official API documentation |
-| --- | --- |
-| Go | [pkg.go.dev](https://pkg.go.dev/github.com/katzenpost/katzenpost/client/thin) |
-| Rust | [docs.rs](https://docs.rs/katzenpost_thin_client/latest/katzenpost_thin_client/) |
-| Python | [Python Thin Client API](/docs/python_thin_client_api/) |
+| Language | Official API documentation | Official API release |
+| --- | --- | --- |
+| Go | [pkg.go.dev](https://pkg.go.dev/github.com/katzenpost/katzenpost/client/thin) | [git tags](https://github.com/katzenpost/katzenpost/tags) |
+| Rust | [docs.rs](https://docs.rs/katzenpost_thin_client/latest/katzenpost_thin_client/) | [crates.io](https://crates.io/crates/katzenpost_thin_client) |
+| Python | [Python Thin Client API](/docs/python_thin_client_api/) | [PyPI](https://pypi.org/project/katzenpost_thinclient/) |
 
 This reference describes the following pinned binding versions:
 


### PR DESCRIPTION
Alongside the documentation links, readers will wish to find the published artefact for each binding. A second column now points to the release listing: PyPI for Python, crates.io for Rust. Go has no package registry, its modules being released as VCS tags and the repository carrying no formal GitHub releases, so the git tags page serves as the truthful equivalent. The overlay source is amended and the combined reference regenerated from the pinned tags; the sole change is this table.