### PR TITLE
Remove excess space above the docs wizard

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,8 +8,6 @@ no_list: true
 body_class: "td-no-sidebar"
 ---
 
-<br/><br/><br/><br/><br/><br/>
-
 <img src="/images/ZII-WIZ3.png" alt="ANSI wizard casting a spell, by Zeus" class="img-fluid mb-4" style="max-width: 640px;">
 
 ## For users


### PR DESCRIPTION
Six literal br tags stood between the page title and the wizard image, pushing it far down the page to no purpose; the layout renders the heading itself and needs no such compensation.